### PR TITLE
Update ElasticsearchAdapter.ts to add code to get information about disk allocation

### DIFF
--- a/src/services/ElasticsearchAdapter.ts
+++ b/src/services/ElasticsearchAdapter.ts
@@ -64,6 +64,11 @@ export default class ElasticsearchAdapter {
     const query = filter ? `${filter}*` : ''
     return this.request(`_cat/shards/${query}`, 'GET', params)
   }
+#hector test allocation
+  catShards (params: object, filter?: string) {
+    const query = filter ? `${filter}*` : ''
+    return this.request(`_cat/allocation/${query}`, 'GET', params)
+  }
 
   indexGetAlias ({ index }: { index: string }) {
     return this.request(`${index}/_alias`, 'GET')


### PR DESCRIPTION
Add code to get information about disk allocation

  catShards (params: object, filter?: string) {
    const query = filter ? `${filter}*` : ''
    return this.request(`_cat/allocation/${query}`, 'GET', params)
  }